### PR TITLE
新增一个选项用于禁用 Sodium 对于 PojavLauncher 的警告 (1.20.2-Holy)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/compatibility/checks/LateDriverScanner.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compatibility/checks/LateDriverScanner.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.compatibility.checks;
 
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaDriverVersion;
 import me.jellysquid.mods.sodium.client.gui.console.Console;
 import me.jellysquid.mods.sodium.client.gui.console.message.MessageLevel;
@@ -19,11 +20,9 @@ public class LateDriverScanner {
     public static void onContextInitialized() {
         checkContextImplementation();
 
-        if (isUsingPojavLauncher()) {
-            Console.instance().logMessage(MessageLevel.SEVERE, Text.translatable("sodium.console.pojav_launcher"), 30.0);
-            LOGGER.error("It appears that PojavLauncher is being used with an OpenGL compatibility layer. This will " +
-                    "likely cause severe performance issues, graphical issues, and crashes when used with Sodium. This " +
-                    "configuration is not supported -- you are on your own!");
+        if ((!SodiumClientMod.options().pojav.noLongerWarnPojavLauncher) && isUsingPojavLauncher()) {
+            Console.instance().logMessage(MessageLevel.WARN, Text.translatable("sodium.console.pojav_launcher"), 30.0);
+            LOGGER.info("modified version of Sodium is running on PojavLauncher, if you run into any problems please report the problem to ConfectionaryQwQ and not to the Sodium team");
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -346,4 +346,20 @@ public class SodiumGameOptionPages {
 
         return new OptionPage(Text.translatable("sodium.options.pages.advanced"), ImmutableList.copyOf(groups));
     }
+
+    public static OptionPage pojavLauncher() {
+        List<OptionGroup> groups = new ArrayList<>();
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName(Text.translatable("sodium.options.pojav_launcher"))
+                        .setTooltip(Text.translatable("sodium.options.pojav_launcher.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.pojav.noLongerWarnPojavLauncher = value, opts -> opts.pojav.noLongerWarnPojavLauncher)
+                        .build()
+                )
+                .build());
+
+        return new OptionPage(Text.translatable("sodium.options.pages.pojav_launcher"), ImmutableList.copyOf(groups));
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -24,6 +24,8 @@ public class SodiumGameOptions {
     public final PerformanceSettings performance = new PerformanceSettings();
     public final NotificationSettings notifications = new NotificationSettings();
 
+    public final PojavLauncherSettings pojav = new PojavLauncherSettings();
+
     private boolean readOnly;
 
     private Path configPath;
@@ -63,6 +65,10 @@ public class SodiumGameOptions {
 
     public static class NotificationSettings {
         public boolean hideDonationButton = false;
+    }
+
+    public static class PojavLauncherSettings {
+        public boolean noLongerWarnPojavLauncher = false;
     }
 
     public enum GraphicsQuality implements TextProvider {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -53,6 +53,7 @@ public class SodiumOptionsGUI extends Screen {
         this.pages.add(SodiumGameOptionPages.quality());
         this.pages.add(SodiumGameOptionPages.performance());
         this.pages.add(SodiumGameOptionPages.advanced());
+        this.pages.add(SodiumGameOptionPages.pojavLauncher());
     }
 
     public void setPage(OptionPage page) {

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -56,8 +56,12 @@
   "sodium.options.buttons.donate": "Buy us a coffee!",
   "sodium.console.game_restart": "The game must be restarted to apply one or more video settings!",
   "sodium.console.broken_nvidia_driver": "Your NVIDIA graphics drivers are out of date!\n  * This will cause severe performance issues and crashes when Sodium is installed.\n  * Please update your graphics drivers to the latest version (version 536.23 or newer.)",
-  "sodium.console.pojav_launcher": "PojavLauncher is not supported when using Sodium.\n  * You are very likely to run into extreme performance issues, graphical bugs, and crashes.\n  * You will be on your own if you decide to continue -- we will not help you with any bugs or crashes!",
+  "sodium.console.pojav_launcher": "PojavLauncher is not supported by the original Sodium version.\n * You are likely to experience extreme performance issues, graphical errors, and crashes.\n * Send feedback to ConfectionaryQwQ for questions about this modified version of Sodium\n\nYou can permanently turn off this warning in the \"Video Settings...\"",
   "sodium.console.core_shaders_error": "The following resource packs are incompatible with Sodium:",
   "sodium.console.core_shaders_warn": "The following resource packs may be incompatible with Sodium:",
-  "sodium.console.core_shaders_info": "Check the game log for detailed information."
+  "sodium.console.core_shaders_info": "Check the game log for detailed information.",
+
+  "sodium.options.pages.pojav_launcher": "PojavLauncher",
+  "sodium.options.pojav_launcher": "No longer warn PojavLauncher",
+  "sodium.options.pojav_launcher.tooltip": "If enabled, Sodium will no longer warn you that you are running Sodium with PojavLauncher\n(Need to restart the game)"
 }

--- a/src/main/resources/assets/sodium/lang/zh_cn.json
+++ b/src/main/resources/assets/sodium/lang/zh_cn.json
@@ -1,0 +1,7 @@
+{
+  "sodium.console.pojav_launcher": "PojavLauncher 不被 Sodium 原版所支持。\n * 你很可能会遇到极端的性能问题、图形错误和崩溃。\n * 关于此魔改版 Sodium 的相关问题，请反馈给 ConfectionaryQwQ\n\n你可以在\"视频设置...\"内永久关闭此警告",
+
+  "sodium.options.pages.pojav_launcher": "PojavLauncher",
+  "sodium.options.pojav_launcher": "不再警告 PojavLauncher",
+  "sodium.options.pojav_launcher.tooltip": "如果启用，Sodium 将不再警告你正在使用 PojavLauncher 运行 Sodium\n(需要重启游戏)"
+}


### PR DESCRIPTION
- 修改了使用PojavLauncher启动游戏时弹出的“严重的”警告（修改了警告内容，将“严重的”改为“警告”）
- 在“视频设置...”屏幕中添加了新的标签页“PojavLauncher”
- 在新的标签页内添加了用于禁用启动游戏时弹出的警告，默认关闭